### PR TITLE
Update package version to 3.4.0

### DIFF
--- a/Eigen
+++ b/Eigen
@@ -1,0 +1,1 @@
+upstream/Eigen

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: Eigen
-version: 3.3.9
+version: 3.4.0
 summary: Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.
 license: MPLv2, LGPLv2.1, BSD2
 license: MPLv2, LGPLv2.1


### PR DESCRIPTION
Hi build2 team,

Glad to use your build system, I really like your approach.
Just bumped the version of the Eigen upstream to 3.4.0 and added the (probably missing) sym-link to the Eigen source directory.
Most importantly the older version prevented me to use Eigen 3 with a resent msvc as `std::result_of` is not available anymore. The use of it in Eigen was removed in 3.4.0.

Eigen 3.4.0 Release notes:
https://eigen.tuxfamily.org/index.php?title=3.4

Link to build2 CI:
https://ci.cppget.org/@71ade087-d4db-40f3-be66-835097d987eb

Comments and feedback welcome.